### PR TITLE
Add ARM64 8.2 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ nginx_version: 1.13.12
 nginx_devel_kit_version: 0.3.0
 nginx_lua_rocks_version: 3.0.4
 nginx_lua_module_version: 0.10.14
+nginx_luajit_git_version: v2.1
+nginx_luajit_repository: https://github.com/LuaJIT/LuaJIT.git
+nginx_luajit_bin_name: luajit-2.1.0-beta3
 
 nginx_sources:
   - http://nginx.org/download/nginx-{{nginx_version}}.tar.gz
@@ -94,7 +97,7 @@ nginx_compile_flags:
    --with-stream
    --with-stream_ssl_module
    --with-debug
-   --with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic'
+   --with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 {{nginx_arch_flags}}'
    --with-ld-opt='-Wl,-E'
    --add-module=../ngx_devel_kit-{{nginx_devel_kit_version}}
    --add-module=../lua-nginx-module-{{nginx_lua_module_version}}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,8 +41,8 @@ nginx_version: 1.13.12
 nginx_devel_kit_version: 0.3.0
 nginx_lua_rocks_version: 3.0.4
 nginx_lua_module_version: 0.10.14
-nginx_luajit_git_version: v2.1
-nginx_luajit_repository: https://github.com/LuaJIT/LuaJIT.git
+nginx_luajit_git_version: v2.1-20201229
+nginx_luajit_repository: https://github.com/openresty/luajit2.git
 nginx_luajit_bin_name: luajit-2.1.0-beta3
 
 nginx_sources:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,9 @@
 - include: install/repository_nginx.yml
   when: nginx_install_repo
 
+- include: install/compiled_luajit.yml
+  when: nginx_install_compiled and nginx_compiled_luajit_git
+
 - include: install/compiled_nginx.yml
   when: nginx_install_compiled
 

--- a/tasks/install/compiled_lua.yml
+++ b/tasks/install/compiled_lua.yml
@@ -5,7 +5,7 @@
 
 - name: Configure lua rocks source code
   command: >
-    ./configure
+    ./configure {{nginx_lua_rocks_configure_args}}
   args:
     chdir: /usr/local/src/luarocks-{{nginx_lua_rocks_version}}
 

--- a/tasks/install/compiled_luajit.yml
+++ b/tasks/install/compiled_luajit.yml
@@ -1,0 +1,44 @@
+---
+#
+# Compile and install nginx using source code
+#
+
+- name: Download LuaJIT sources
+  git:
+    repo: "{{nginx_luajit_repository}}"
+    dest: /usr/local/src/luajit.git
+    version: "{{nginx_luajit_git_version}}"
+    accept_hostkey: yes
+    force: yes
+
+- name: Build LuaJIT
+  make:
+    chdir: /usr/local/src/luajit.git
+
+- name: Install LuaJIT
+  make:
+    chdir: /usr/local/src/luajit.git
+    target: install
+    params:
+      PREFIX: /usr/local/luajit
+  become: true
+
+- name: Configure LuaJIT ld.so.conf
+  copy:
+    dest: /etc/ld.so.conf.d/luajit.conf
+    content: /usr/local/luajit
+    mode: 640
+  become: true
+
+- name: Run ldconfig for LuaJIT
+  command: ldconfig
+  become: true
+
+- name: Create symlink for LuaJIT
+  file:
+    state: link
+    src: "/usr/local/luajit/bin/{{nginx_luajit_bin_name}}"
+    path: /usr/local/luajit/bin/luajit
+  become: true
+
+# vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/compiled_nginx.yml
+++ b/tasks/install/compiled_nginx.yml
@@ -35,10 +35,11 @@
   with_items: "{{nginx_sources}}"
 
 - name: Configure nginx source code
-  shell: >
-    {{nginx_configure_environ}} ./configure {{nginx_compile_flags}}
+  command: >
+    ./configure {{nginx_compile_flags}}
   args:
     chdir: /usr/local/src/nginx-{{nginx_version}}
+  environment: "{{ nginx_configure_environ }}"
 
 - name: Build source code
   make:

--- a/tasks/install/compiled_nginx.yml
+++ b/tasks/install/compiled_nginx.yml
@@ -35,8 +35,8 @@
   with_items: "{{nginx_sources}}"
 
 - name: Configure nginx source code
-  command: >
-    ./configure {{nginx_compile_flags}}
+  shell: >
+    {{nginx_configure_environ}} ./configure {{nginx_compile_flags}}
   args:
     chdir: /usr/local/src/nginx-{{nginx_version}}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,10 @@
   include_vars: "{{ansible_os_family}}.yml"
   tags: always
 
+- name: Include Arch vars
+  include_vars: "{{ansible_architecture}}.yml"
+  tags: always
+
 - include: install.yml
   tags: nginx_install
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -13,7 +13,7 @@ nginx_compilation_packages: []
 nginx_compilation_arch_packages: []
 
 nginx_compiled_luajit_git: false
-nginx_configure_environ: ""
+nginx_configure_environ: {}
 nginx_lua_rocks_configure_args: ""
 
 nginx_pid_file: /run/nginx.pid

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,6 +10,11 @@ nginx_repo_packages:
   - openssl
 
 nginx_compilation_packages: []
+nginx_compilation_arch_packages: []
+
+nginx_compiled_luajit_git: false
+nginx_configure_environ: ""
+nginx_lua_rocks_configure_args: ""
 
 nginx_pid_file: /run/nginx.pid
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -19,7 +19,7 @@ nginx_compilation_arch_packages:
   - luajit-devel
 
 nginx_compiled_luajit_git: false
-nginx_configure_environ: ""
+nginx_configure_environ: {}
 nginx_lua_rocks_configure_args: ""
 
 nginx_pid_file: /var/run/nginx.pid

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -14,7 +14,13 @@ nginx_compilation_packages:
   - openssl-devel
   - pcre-devel
   - zlib-devel
+
+nginx_compilation_arch_packages:
   - luajit-devel
+
+nginx_compiled_luajit_git: false
+nginx_configure_environ: ""
+nginx_lua_rocks_configure_args: ""
 
 nginx_pid_file: /var/run/nginx.pid
 

--- a/vars/aarch64.yml
+++ b/vars/aarch64.yml
@@ -1,7 +1,9 @@
 nginx_compilation_arch_packages:
   - git
 nginx_compiled_luajit_git: true
-nginx_configure_environ: "LUAJIT_LIB=/usr/local/luajit/lib LUAJIT_INC=/usr/local/luajit/include/luajit-2.1"
+nginx_configure_environ:
+  LUAJIT_LIB: /usr/local/luajit/lib
+  LUAJIT_INC: /usr/local/luajit/include/luajit-2.1
 nginx_lua_rocks_configure_args: --with-lua=/usr/local/luajit
 
 nginx_arch_flags: "-mtune=generic"

--- a/vars/aarch64.yml
+++ b/vars/aarch64.yml
@@ -1,0 +1,8 @@
+nginx_compilation_arch_packages:
+  - git
+nginx_compiled_luajit_git: true
+nginx_configure_environ: "LUAJIT_LIB=/usr/local/luajit/lib LUAJIT_INC=/usr/local/luajit/include/luajit-2.1"
+nginx_lua_rocks_configure_args: --with-lua=/usr/local/luajit
+
+nginx_arch_flags: "-mtune=generic"
+

--- a/vars/x86_64.yml
+++ b/vars/x86_64.yml
@@ -1,0 +1,1 @@
+nginx_arch_flags: "-m64 -mtune=generic"


### PR DESCRIPTION
By compiling luajit 2.1 from git directly, which is the most
stable version of luajit that supports ARM64 at the moment.

Rework things to make the process dependent on architecture, and
make compiling luajit 2.1 from git the default behavior in ARM64
architectures.